### PR TITLE
codec-68-bug-outboundmessageencoder-not-implement-header

### DIFF
--- a/src/main/java/io/github/ppzxc/codec/model/Header.java
+++ b/src/main/java/io/github/ppzxc/codec/model/Header.java
@@ -9,6 +9,8 @@ public class Header implements Serializable {
   public static final int PROTOCOL_FIELDS_LENGTH = 4;
   public static final int BODY_LENGTH = ID_FIELD_LENGTH + PROTOCOL_FIELDS_LENGTH + LineDelimiter.LENGTH;
   public static final int MINIMUM_LENGTH = LENGTH_FIELD_LENGTH + BODY_LENGTH;
+  public static final int ENCRYPTED_EMPTY_FULL_LENGTH = 30;
+  public static final int ENCRYPTED_EMPTY_BODY_LENGTH = ENCRYPTED_EMPTY_FULL_LENGTH - LENGTH_FIELD_LENGTH;
   private static final long serialVersionUID = 3858154716183837451L;
   private final int length;
   private final long id;


### PR DESCRIPTION
- OutboundMessageEncoder.java 에서 length 필드 외 payload 모두 암호화